### PR TITLE
added functionality to the admin view that deletes orphan guest carts

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -84,6 +84,21 @@ export async function getNewGuestCart() {
   }catch(error) {throw error}
 }
 
+export async function guestCartCleanup() {
+  try {
+    const response = await fetch(`${BASE}carts/guestcartcleanup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+    }
+  })
+  const result = await response.json();
+  return result.success
+
+} catch(error) {throw error}
+}
+
 export async function getAllProducts() {
   try {
     const response = await fetch(`${BASE}products`, {

--- a/src/components/AdminPage/AdminDB/DbCleanup.js
+++ b/src/components/AdminPage/AdminDB/DbCleanup.js
@@ -1,0 +1,29 @@
+import React from "react";
+import { guestCartCleanup } from "../../../api";
+
+const DbCleanup = () => {
+function handleCleanupButton () {
+    (async()=>{
+        const result = await guestCartCleanup();
+        if (result) alert("Cleanup was successful")
+        else alert("Something went wrong with cleanup")
+    })()
+}
+
+return (<>
+    <h5>Clicking the button below:</h5>
+    <ul>
+        <li>WILL delete non-purchased guest carts from the db</li>
+        <li>WILL delete the carts associated with those items</li>
+        <li>WILL NOT affect logged in users</li>
+        <li>WILL NOT delete the cart items stored client-side, even for guest users</li>
+    </ul>
+    <h5>Guests who are currently checking out will<br></br>need to restart the checkout process</h5>
+    
+    <button type="submit" className="btn btn-primary me-3" onClick={handleCleanupButton}>Delete Guest Carts</button>
+
+    </>
+)
+}
+
+export default DbCleanup

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,7 +22,8 @@ import {
     AdminCategories,
     NotFoundRoute,
     Wishlist,
-    OrderSuccess
+    OrderSuccess,
+    DbCleanup
 } from "./"
 import CreateAddress from "./Profile/CreateAddress";
 import EditAddress from "./Profile/EditAddress";
@@ -113,6 +114,7 @@ const App = () => {
             <Route path="/admin/orders" element={<AdminOrders />}/>
             
             <Route path="/admin/categories" element={<AdminCategories />}/>
+            <Route path="/admin/dbCleanup" element={<DbCleanup />} />
 
             <Route path="/wishlist" element={<Wishlist />} />
             <Route path='/OrderSuccess' element={<OrderSuccess />}/>

--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -92,6 +92,11 @@ const NavBar = (props) => {
                       Orders
                     </NavLink>
                   </li>
+                  <li className="nav-item">
+                    <NavLink className="nav-link" to="/admin/dbCleanup">
+                      DB Maintenance
+                    </NavLink>
+                  </li>
                 </>
               ) : null}
               {token && !isUserAdmin ? (

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,6 +10,7 @@ export { default as AdminProducts } from "./AdminPage/AdminProducts/AdminProduct
 export { default as SingleAdminProduct } from "./AdminPage/AdminProducts/SingleAdminProduct";
 export { default as Homepage } from "./Homepage/Homepage";
 export { default as AdminUsers } from "./AdminPage/AdminUsers/AdminUsers";
+export { default as DbCleanup } from "./AdminPage/AdminDB/DbCleanup";
 export { default as SingleAdminUser } from "./AdminPage/AdminUsers/SingleAdminUser";
 export { default as SearchForm } from "./SearchForm/SearchForm";
 export { default as Header } from "./Header/Header";


### PR DESCRIPTION
Adds component to admin view to clean up orphaned guest carts.  These carts are not retrievable from the front end, and they'll be re-created if the user returns to the checkout page--all the items are still stored in local storage on the client side unless the user has explicitly deleted the data.